### PR TITLE
[Fix][Print-PDF] Adjust width of CV container to prevent cropping during PDF export

### DIFF
--- a/src/components/DownloadOptions.tsx
+++ b/src/components/DownloadOptions.tsx
@@ -13,7 +13,7 @@ export function DownloadOptions({ cvData }: DownloadOptionsProps) {
   const [isGenerating, setIsGenerating] = useState(false);
 
   const generateHtmlContent = (): string => {
-    const cvDocument = document.querySelector("#cv-preview") as HTMLElement;
+    const cvDocument = document.querySelector("#cv-preview").cloneNode(true) as HTMLElement;
     cvDocument.style = "width: auto;";
     const content = cvDocument?.outerHTML;
 

--- a/src/components/DownloadOptions.tsx
+++ b/src/components/DownloadOptions.tsx
@@ -13,7 +13,9 @@ export function DownloadOptions({ cvData }: DownloadOptionsProps) {
   const [isGenerating, setIsGenerating] = useState(false);
 
   const generateHtmlContent = (): string => {
-    const content = document.querySelector("#cv-preview").outerHTML;
+    const cvDocument = document.querySelector("#cv-preview") as HTMLElement;
+    cvDocument.style = "width: auto;";
+    const content = cvDocument?.outerHTML;
 
     return `
     <!doctype html>


### PR DESCRIPTION
While printing or saving the CV as a PDF, the sides of the content were being cropped. This issue was caused by the width property applied to the CV container, which caused overflow and cropping when the content was rendered for PDF export.

Before fix:
<img width="933" alt="Screenshot 2025-03-22 at 8 30 38 PM" src="https://github.com/user-attachments/assets/63d3a052-332e-4418-b633-73b6a91f5b5f" />

After fix:
<img width="933" alt="Screenshot 2025-03-22 at 8 30 05 PM" src="https://github.com/user-attachments/assets/c1b2854a-977c-433d-9191-4d6b3d3c80ae" />