### PR TITLE
[Fix][Preview-Education] Add validation on educations dates, only show the Calender and dates if user provided start and end dates.

### DIFF
--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -263,12 +263,14 @@ export function Preview({ data }: PreviewProps) {
                     <div className="text-gray-700">{edu.institute}</div>
                     {edu.location && <div className="text-sm text-gray-600">{edu.location}</div>}
                   </div>
-                  <div className="flex items-center gap-1 text-sm text-gray-600">
+                  {edu.startDate && (edu.current || edu.endDate) && 
+                    <div className="flex items-center gap-1 text-sm text-gray-600">
                     <Calendar className="h-3 w-3" />
                     <span>
                       {formatDate(edu.startDate)} - {edu.current ? 'Present' : formatDate(edu.endDate)}
                     </span>
-                  </div>
+                    </div>
+                  }
                 </div>
               </div>
             ))}


### PR DESCRIPTION
Add validation on educations dates, only show the Calender and dates if user provided start and end dates.

Before fix:
<img width="1440" alt="Screenshot 2025-03-22 at 10 04 14 PM" src="https://github.com/user-attachments/assets/5e4a07b9-83e8-4e79-b509-53eeec9f7e35" />

After fix:
<img width="1440" alt="Screenshot 2025-03-22 at 10 03 53 PM" src="https://github.com/user-attachments/assets/ab170c98-651e-45c3-8e34-41611cfcb9c8" />


